### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,12 @@ class ApplicationController < ActionController::Base
       devise_parameter_sanitizer.permit(:sign_up, keys: [:email, :password, :password_confirmation, :nickname, :firstname_kanji, :lirstname_kanji, :firstname_kana, :lastname_kana, :birthday])
     end
   end
+  def authenticate_user!
+    unless user_signed_in?
+      redirect_to new_user_session_path, alert: 'You need to sign in before editing items.'
+    end
+  end
+
 
   def set_active_storage_url_options
     ActiveStorage::Current.url_options = {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth
-  before_action :set_active_storage_url_options  # Add this line
+  before_action :set_active_storage_url_options  
   before_action :configure_sign_up_params, only: [:create], if: :devise_controller?
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,7 +24,13 @@ end
 def show
   @item = Item.find(params[:id])
 end
-
+def update
+  if @item.update(item_params)
+    redirect_to @item, notice: '商品が更新されました。'
+  else
+    render :edit
+  end
+end
   # Other methods...
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,59 +1,65 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit]
+  before_action :set_item, only: [:edit, :update, :show]
 
   def new
     @item = Item.new
   end
-def create
-  @item = current_user.items.build(item_params)
 
-  if @item.save
-    redirect_to root_path, notice: 'Item was successfully created.'
-  else
-    render :new, status: :unprocessable_entity
-    @categories = Category.all  
-    @situations = Situation.all
-    @postages = Postage.all
-    @prefectures = Prefecture.all
-    @deliverydays = Deliveryday.all
+  def create
+    @item = current_user.items.build(item_params)
+
+    if @item.save
+      redirect_to root_path, notice: 'Item was successfully created.'
+    else
+      render :new, status: :unprocessable_entity
+      load_select_options
+    end
   end
-end
-def index
-  @items = Item.all
-end
 
-def edit
-  @item = Item.find(params[:id])
-
-
-  unless current_user == @item.user
-    redirect_to new_user_session_path, alert: 'Please log in to edit this item.'
+  def index
+    @items = Item.all
   end
-end
 
-
-def show
-  @item = Item.find(params[:id])
-end
-
-
-def update
-  @item = Item.find(params[:id])
-
-  if @item.update(item_params)
-    redirect_to @item, notice: '商品が更新されました。'
-  else
-    render :edit, status: :unprocessable_entity
+  def edit
+    redirect_if_not_item_owner
   end
-end
 
+  def show
+    
+  end
 
+  def update
+    redirect_if_not_item_owner
 
-
+    if @item.update(item_params)
+      redirect_to @item, notice: '商品が更新されました。'
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
 
   private
 
   def item_params
     params.require(:item).permit(:image, :item_name, :item_explanation, :category_id, :situation_id, :postage_id, :prefecture_id, :deliveryday_id, :price)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
+  def load_select_options
+    @categories = Category.all
+    @situations = Situation.all
+    @postages = Postage.all
+    @prefectures = Prefecture.all
+    @deliverydays = Deliveryday.all
+  end
+
+  def redirect_if_not_item_owner
+    unless current_user == @item.user
+      redirect_to new_user_session_path, alert: 'Please log in to edit this item.'
+    end
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,16 +21,25 @@ end
 def index
   @items = Item.all
 end
+def edit
+  @item = Item.find(params[:id])
+end
 def show
   @item = Item.find(params[:id])
 end
+
+
 def update
+  @item = Item.find(params[:id])
   if @item.update(item_params)
     redirect_to @item, notice: '商品が更新されました。'
   else
     render :edit
   end
 end
+
+
+
   # Other methods...
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,6 +31,7 @@ end
 
 def update
   @item = Item.find(params[:id])
+
   if @item.update(item_params)
     redirect_to @item, notice: '商品が更新されました。'
   else

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit]
 
   def new
     @item = Item.new
@@ -21,9 +21,17 @@ end
 def index
   @items = Item.all
 end
+
 def edit
   @item = Item.find(params[:id])
+
+  # Ensure that only the item's owner can edit
+  unless current_user == @item.user
+    redirect_to new_user_session_path, alert: 'Please log in to edit this item.'
+  end
 end
+
+
 def show
   @item = Item.find(params[:id])
 end
@@ -35,7 +43,7 @@ def update
   if @item.update(item_params)
     redirect_to @item, notice: '商品が更新されました。'
   else
-    render :edit
+    render :edit, status: :unprocessable_entity
   end
 end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,7 +11,7 @@ def create
     redirect_to root_path, notice: 'Item was successfully created.'
   else
     render :new, status: :unprocessable_entity
-    @categories = Category.all  # カテゴリーなどの選択肢を再度取得
+    @categories = Category.all  
     @situations = Situation.all
     @postages = Postage.all
     @prefectures = Prefecture.all
@@ -25,7 +25,7 @@ end
 def edit
   @item = Item.find(params[:id])
 
-  # Ensure that only the item's owner can edit
+
   unless current_user == @item.user
     redirect_to new_user_session_path, alert: 'Please log in to edit this item.'
   end
@@ -49,7 +49,7 @@ end
 
 
 
-  # Other methods...
+
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,7 +33,7 @@ class ItemsController < ApplicationController
     redirect_if_not_item_owner
 
     if @item.update(item_params)
-      redirect_to @item, notice: '商品が更新されました。'
+      redirect_to item_path(@item), notice: '商品が更新されました。'
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,5 +1,4 @@
-<%# cssは商品出品のものを併用しています。
-app/assets/stylesheets/items/new.css %>
+
 
 <div class="items-sell-contents">
   <header class="items-sell-header">
@@ -13,7 +12,7 @@ app/assets/stylesheets/items/new.css %>
 
     <%= render 'shared/error_messages', model: form.object %>
 
-    <%# 商品画像 %>
+   
     <div class="img-upload">
       <div class="weight-bold-text">
         商品画像
@@ -26,8 +25,7 @@ app/assets/stylesheets/items/new.css %>
         <%= form.file_field :image, id: "item-image" %>
       </div>
     </div>
-    <%# /商品画像 %>
-    <%# 商品名と商品説明 %>
+    
     <div class="new-items">
       <div class="weight-bold-text">
         商品名
@@ -42,9 +40,6 @@ app/assets/stylesheets/items/new.css %>
         <%= form.text_area :item_explanation, class: "items-text", id: "item-info", placeholder: "商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", rows: "7", maxlength: "1000" %>
       </div>
     </div>
-    <%# /商品名と商品説明 %>
-
-    <%# 商品の詳細 %>
     <div class="items-detail">
       <div class="weight-bold-text">商品の詳細</div>
       <div class="form">
@@ -60,9 +55,6 @@ app/assets/stylesheets/items/new.css %>
         <%= form.collection_select(:situation_id, Situation.all, :id, :name, { id: 1, name: '---' }, class: "select-box", id: "item-sales-status") %>
       </div>
     </div>
-    <%# /商品の詳細 %>
-
-    <%# 配送について %>
     <div class="items-detail">
       <div class="weight-bold-text question-text">
         <span>配送について</span>
@@ -118,9 +110,6 @@ app/assets/stylesheets/items/new.css %>
         </div>
       </div>
     </div>
-    <%# /販売価格 %>
-
-    <%# 注意書き %>
     <div class="caution">
       <p class="sentence">
         <a href="#">禁止されている出品、</a>
@@ -138,8 +127,7 @@ app/assets/stylesheets/items/new.css %>
         に同意したことになります。
       </p>
     </div>
-    <%# /注意書き %>
-    <%# 下部ボタン %>
+   
     <div class="sell-btn-contents">
       <%= form.submit "変更する" ,class:"sell-btn" %>
       <%= link_to 'もどる', item_path(@item), class: 'back-btn' %>
@@ -147,7 +135,6 @@ app/assets/stylesheets/items/new.css %>
 
 
     </div>
-    <%# /下部ボタン %>
   </div>
   <% end %>
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,8 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, url: item_path(@item), method: :patch do |form| %>
+
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%# render 'shared/error_messages', model: f.object %>
@@ -23,7 +24,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :item_image, id: "item-image" %>
+        <%= form.file_field :image, id: "item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +34,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :item_name, class: "items-text", id: "item-name", placeholder: "商品名（必須 40文字まで)", maxlength: "40" %>
+      <%= form.text_area :item_name, class: "items-text", id: "item-name", placeholder: "商品名（必須 40文字まで)", maxlength: "40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :item_description, class: "items-text", id: "item-info", placeholder: "商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", rows: "7", maxlength: "1000" %>
+        <%= form.text_area :item_explanation, class: "items-text", id: "item-info", placeholder: "商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", rows: "7", maxlength: "1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +53,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select :category_id, Category.all, :id, :name, { id: 1, name: '---' }, class: "select-box", id:"item-category" %>
+        <%= form.collection_select(:category_id, Category.all, :id, :name, { id: 1, name: '---' }, class: "select-box", id: "item-category") %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select :situation_id, Situation.all, :id, :name, { id: 1, name: '---' }, class: "select-box", id: "item-sales-status" %>
+        <%= form.collection_select(:situation_id, Situation.all, :id, :name, { id: 1, name: '---' }, class: "select-box", id: "item-sales-status") %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +74,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select :postage_id, Postage.all, :id, :name, { id: 1, name: '---' }, class: "select-box", id: "item-shipping-fee-status" %>
+        <%= form.collection_select(:postage_id, Postage.all, :id, :name, { id: 1, name: '---' }, class: "select-box", id: "item-shipping-fee-status") %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, { id: 1, name: '---' }, class: "select-box", id: "item-prefecture" %>
+        <%= form.collection_select(:prefecture_id, Prefecture.all, :id, :name, { id: 1, name: '---' }, class: "select-box", id: "item-prefecture") %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select :deliveryday_id, Deliveryday.all, :id, :name, { id: 1, name: '---' }, class: "select-box", id: "item-scheduled-delivery" %>
+        <%= form.collection_select(:deliveryday_id, Deliveryday.all, :id, :name, { id: 1, name: '---' }, class: "select-box", id: "item-scheduled-delivery") %>
 
       </div>
     </div>
@@ -102,7 +103,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :price, class: "price-input", id: "item-price", placeholder: "例）300" %>
+          <%= form.text_field :price, class: "price-input", id: "item-price", placeholder: "半角数字で入力" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +142,7 @@ app/assets/stylesheets/items/new.css %>
     <%# /注意書き %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
+      <%= form.submit "変更する" ,class:"sell-btn" %>
       <%=link_to 'もどる', "#", class:"back-btn" %>
     </div>
     <%# /下部ボタン %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -11,9 +11,7 @@ app/assets/stylesheets/items/new.css %>
 
 
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: form.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :item_image, id: "item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :item_name, class: "items-text", id: "item-name", placeholder: "商品名（必須 40文字まで)", maxlength: "40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :item_description, class: "items-text", id: "item-info", placeholder: "商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", rows: "7", maxlength: "1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select :category_id, Category.all, :id, :name, { id: 1, name: '---' }, class: "select-box", id:"item-category" %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select :situation_id, Situation.all, :id, :name, { id: 1, name: '---' }, class: "select-box", id: "item-sales-status" %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,18 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select :postage_id, Postage.all, :id, :name, { id: 1, name: '---' }, class: "select-box", id: "item-shipping-fee-status" %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, { id: 1, name: '---' }, class: "select-box", id: "item-prefecture" %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select :deliveryday_id, Deliveryday.all, :id, :name, { id: 1, name: '---' }, class: "select-box", id: "item-scheduled-delivery" %>
+
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +102,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class: "price-input", id: "item-price", placeholder: "例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -10,6 +10,7 @@ app/assets/stylesheets/items/new.css %>
     <%= form_with model: @item, url: item_path(@item), method: :patch do |form| %>
 
 
+
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%# render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
@@ -143,7 +144,10 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= form.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%= link_to 'もどる', item_path(@item), class: 'back-btn' %>
+
+
+
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -39,9 +39,7 @@
         <%= form.text_area :item_explanation, class: "items-text", id: "item-info", placeholder: "商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", rows: "7", maxlength: "1000" %>
       </div>
     </div>
-    <%# /商品名と商品説明 %>
-
-    <%# 商品の詳細 %>
+    
     <div class="items-detail">
       <div class="weight-bold-text">商品の詳細</div>
       <div class="form">
@@ -57,9 +55,7 @@
         <%= form.collection_select(:situation_id, Situation.all, :id, :name, { id: 1, name: '---' }, class: "select-box", id: "item-sales-status") %>
       </div>
     </div>
-    <%# /商品の詳細 %>
-
-    <%# 配送について %>
+    
     <div class="items-detail">
       <div class="weight-bold-text question-text">
         <span>配送について</span>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -8,8 +8,6 @@
     <%= form_with(model: @item, local: true) do |form| %>
 
     <%= render 'shared/error_messages', model: form.object %>
-   
-    
 
 
     <%# 商品画像 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
   
     <% if user_signed_in? %>
       <% if current_user == @item.user %>
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
       <% else %>


### PR DESCRIPTION
What
商品情報編集機能追加
Why
商品の値段を上げ下げできれば世間の需要と供給により値段を変更できるようにするため
ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://i.gyazo.com/61ac3048393078bf84c5007c3b5d6825.mp4
必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://i.gyazo.com/d3f32698dd63661ccf8feb99e7108aa5.mp4
入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://i.gyazo.com/718dce14e94908df592168ef14ebcdde.mp4
何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://i.gyazo.com/f31adca4676a6905f940c7e8c48b8a86.mp4
ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://i.gyazo.com/aad8d1a1f55e7edf4e94ac6c8e796c84.mp4
ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
まだできない
ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://i.gyazo.com/67dcf4533860fc2b012bbfd00cfce0be.mp4
商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い
https://i.gyazo.com/849c8f2b630d392e5293e5a1b68d0bf6.mp4